### PR TITLE
Generate artifacts using gh-actions

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -4,13 +4,7 @@ name: CI
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
-
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows you to run this workflow manually from the Actions tab, do not run automatically
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -25,6 +19,8 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: "Checkout"
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
       
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
@@ -35,6 +31,18 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           julia -e 'include(joinpath(pwd(),"deps","generate_artifacts.jl"))'
+      
+      - name: "Commit updated Artifacts.toml"
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "Update Artifacts.toml" "Artifacts.toml"
+          
+      - name: "Push changes"
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
           
       - name: "Release"
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -44,13 +44,10 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
           
-      - name: "Remove old release"
-        run: git push origin :refs/tags/plotly-artifacts
-          
       - name: "Release"
         uses: ncipollo/release-action@v1
         with:
-          artifact: "plotly-artifacts.tar.gz"
+          artifacts: "plotly-artifacts.tar.gz"
           replacesArtifacts: true
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: "plotly-artifacts"

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -13,6 +13,9 @@ jobs:
   gen-artifacts:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    # The plotly version. Bumping this environment variable should do the trick
+    env: 
+      PLOTLY_VER: 1.58.4
     
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -25,18 +28,18 @@ jobs:
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
         with:
-          version: 1.5.4
+          version: 1.6.0
       
       - name: "Get artifact"
         run: |
           cd $GITHUB_WORKSPACE
-          julia -e 'include(joinpath(pwd(),"deps","generate_artifacts.jl"))'
+          julia -e 'include(joinpath(pwd(),"deps","generate_artifacts.jl")); generate_artifacts("'"$PLOTLY_VER"'")'
       
       - name: "Commit updated Artifacts.toml"
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git commit -m "Update Artifacts.toml" "Artifacts.toml"
+          git commit -m "Update Artifacts.toml for artifact version $PLOTLY_VER" "Artifacts.toml"
           
       - name: "Push changes"
         uses: ad-m/github-push-action@master
@@ -48,7 +51,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
-          artifacts: "plotly-artifacts.tar.gz"
+          artifacts: "plotly-artifacts-${{ env.PLOTLY_VER }}.tar.gz"
           replacesArtifacts: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag: "plotly-artifacts"
+          tag: "plotly-artifacts-${{ env.PLOTLY_VER }}"

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,0 +1,43 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "gen-artifacts"
+  gen-artifacts:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: "Checkout"
+      - uses: actions/checkout@v2
+      
+      - name: "Set up Julia"
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: 1.5.4
+      
+      - name: "Get artifact"
+      - run: |
+          julia -e 'include(joinpath($GITHUB_WORKSPACE,"deps","generate_artifacts.jl"))'
+          
+      - name: "Release"
+        uses: softprops/action-gh-release@v1
+        with:
+          files: "plotly-artifacts.tar.gz"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -44,6 +44,9 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
           
+      - name: "Remove old release"
+        run: git push origin :refs/tags/plotly-artifacts
+          
       - name: "Release"
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -40,5 +40,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: "plotly-artifacts.tar.gz"
+          tag_name: "plotly-artifacts"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: Artifacts
 
 # Controls when the action will run. 
 on:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -47,6 +47,7 @@ jobs:
       - name: "Release"
         uses: ncipollo/release-action@v1
         with:
+          allowUpdates: true
           artifacts: "plotly-artifacts.tar.gz"
           replacesArtifacts: true
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -33,7 +33,8 @@ jobs:
       
       - name: "Get artifact"
         run: |
-          julia -e 'include(joinpath($GITHUB_WORKSPACE,"deps","generate_artifacts.jl"))'
+          cd $GITHUB_WORKSPACE
+          julia -e 'include(joinpath(pwd(),"deps","generate_artifacts.jl"))'
           
       - name: "Release"
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: "Checkout"
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v2
       
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
@@ -32,7 +32,7 @@ jobs:
           version: 1.5.4
       
       - name: "Get artifact"
-      - run: |
+        run: |
           julia -e 'include(joinpath($GITHUB_WORKSPACE,"deps","generate_artifacts.jl"))'
           
       - name: "Release"

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "Get artifact"
         run: |
           cd $GITHUB_WORKSPACE
-          julia -e 'include(joinpath(pwd(),"deps","generate_artifacts.jl")); generate_artifacts("'"$PLOTLY_VER"'")'
+          julia -e 'include(joinpath(pwd(),"deps","generate_artifacts.jl")); generate_artifacts("'"$PLOTLY_VER"'","'"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"'")'
       
       - name: "Commit updated Artifacts.toml"
         run: |

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -48,9 +48,9 @@ jobs:
         run: git push origin :refs/tags/plotly-artifacts
           
       - name: "Release"
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          files: "plotly-artifacts.tar.gz"
-          tag_name: "plotly-artifacts"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          artifact: "plotly-artifacts.tar.gz"
+          replacesArtifacts: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: "plotly-artifacts"

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -4,6 +4,7 @@ on:
     branches: [master]
     tags: [v*]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   docdeploy:

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2,5 +2,5 @@
 git-tree-sha1 = "4fa45e1c116c49318fa3d60adb843b5db5c13069"
 
     [[plotly-artifacts.download]]
-    sha256 = "6d2510f8556db652785bd3690d842455fc9380ace2a4a94dca5e8f11e8b5bcb1"
-    url = "https://github.com/JuliaPlots/PlotlyJS.jl/releases/download/plotly-artifacts-1.58.4/plotly-artifacts-1.58.4.tar.gz"
+    sha256 = "c945e3724a3969e58dee5a9f00e80a256a5c098e0b4ac8c5838c5a538e186c9d"
+    url = "https://github.com/jonas-kr/PlotlyJS.jl/releases/download/plotly-artifacts-1.58.4/plotly-artifacts-1.58.4.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2,5 +2,5 @@
 git-tree-sha1 = "4fa45e1c116c49318fa3d60adb843b5db5c13069"
 
     [[plotly-artifacts.download]]
-    sha256 = "0d8f73c59c4cf602ce513299ee680db59953a1be5c2846a660d359260a46ef77"
-    url = "https://github.com/JuliaPlots/PlotlyJS.jl/releases/download/plotly-artifacts/plotly-artifacts.tar.gz"
+    sha256 = "6d2510f8556db652785bd3690d842455fc9380ace2a4a94dca5e8f11e8b5bcb1"
+    url = "https://github.com/JuliaPlots/PlotlyJS.jl/releases/download/plotly-artifacts-1.58.4/plotly-artifacts-1.58.4.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2,5 +2,5 @@
 git-tree-sha1 = "0fa0fdda797e143a9c68587ee2c78c48f119370a"
 
     [[plotly-artifacts.download]]
-    sha256 = "afd3114df4f2ab370b482602790e126173cee8ec688d4526745078dcef9f5599"
+    sha256 = "e9aac580766bcaf8bbe25712620b6395bf1a2a0eb3131653cee4bbc549770fd7"
     url = "https://github.com/jonas-kr/PlotlyJS.jl/releases/download/plotly-artifacts/plotly-artifacts.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,6 @@
 [plotly-artifacts]
-git-tree-sha1 = "5a25efc3789f8a079d44732c994de47bc76f8de5"
+git-tree-sha1 = "0fa0fdda797e143a9c68587ee2c78c48f119370a"
 
     [[plotly-artifacts.download]]
-    sha256 = "61d736774d0c1346cea0e366442b978b81aacccded179c3010de1eba4cced084"
+    sha256 = "afd3114df4f2ab370b482602790e126173cee8ec688d4526745078dcef9f5599"
     url = "https://github.com/jonas-kr/PlotlyJS.jl/releases/download/plotly-artifacts/plotly-artifacts.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2,5 +2,5 @@
 git-tree-sha1 = "5a25efc3789f8a079d44732c994de47bc76f8de5"
 
     [[plotly-artifacts.download]]
-    sha256 = "2b628067587daffeb87be79bbbe52dc394044e0310f380d95c10b5c096251260"
+    sha256 = "1b597a5fa77dec3383668075296cbcde0a5acf4527e4f37cb815c79a9724cf39"
     url = "https://github.com/jonas-kr/PlotlyJS.jl/releases/download/plotly-artifacts/plotly-artifacts.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,6 @@
 [plotly-artifacts]
-git-tree-sha1 = "0fcbca3e2dac59d4a0f4f3b3fc2de36efe0ca4a1"
+git-tree-sha1 = "5a25efc3789f8a079d44732c994de47bc76f8de5"
 
     [[plotly-artifacts.download]]
-    sha256 = "499fa5e6a60b280c17513b13fbe5b99f37b96870446319bc27a37a137445ea6b"
-    url = "https://github.com/thomasjm/PlotlyJS.jl/releases/download/v0.14/plotly.js-artifacts-1.57.1.tar.gz"
+    sha256 = "2b628067587daffeb87be79bbbe52dc394044e0310f380d95c10b5c096251260"
+    url = "https://github.com/jonas-kr/PlotlyJS.jl/releases/download/plotly-artifacts/plotly-artifacts.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -3,4 +3,4 @@ git-tree-sha1 = "4fa45e1c116c49318fa3d60adb843b5db5c13069"
 
     [[plotly-artifacts.download]]
     sha256 = "0d8f73c59c4cf602ce513299ee680db59953a1be5c2846a660d359260a46ef77"
-    url = "https://github.com/jonas-kr/PlotlyJS.jl/releases/download/plotly-artifacts/plotly-artifacts.tar.gz"
+    url = "https://github.com/JuliaPlots/PlotlyJS.jl/releases/download/plotly-artifacts/plotly-artifacts.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2,5 +2,5 @@
 git-tree-sha1 = "5a25efc3789f8a079d44732c994de47bc76f8de5"
 
     [[plotly-artifacts.download]]
-    sha256 = "1b597a5fa77dec3383668075296cbcde0a5acf4527e4f37cb815c79a9724cf39"
+    sha256 = "65b05f30397368844e6b6b752d3cdbf2aed733b39e620151575a66c7c0fe4094"
     url = "https://github.com/jonas-kr/PlotlyJS.jl/releases/download/plotly-artifacts/plotly-artifacts.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,6 @@
 [plotly-artifacts]
-git-tree-sha1 = "0fa0fdda797e143a9c68587ee2c78c48f119370a"
+git-tree-sha1 = "4fa45e1c116c49318fa3d60adb843b5db5c13069"
 
     [[plotly-artifacts.download]]
-    sha256 = "e9aac580766bcaf8bbe25712620b6395bf1a2a0eb3131653cee4bbc549770fd7"
+    sha256 = "0d8f73c59c4cf602ce513299ee680db59953a1be5c2846a660d359260a46ef77"
     url = "https://github.com/jonas-kr/PlotlyJS.jl/releases/download/plotly-artifacts/plotly-artifacts.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2,5 +2,5 @@
 git-tree-sha1 = "5a25efc3789f8a079d44732c994de47bc76f8de5"
 
     [[plotly-artifacts.download]]
-    sha256 = "65b05f30397368844e6b6b752d3cdbf2aed733b39e620151575a66c7c0fe4094"
+    sha256 = "61d736774d0c1346cea0e366442b978b81aacccded179c3010de1eba4cced084"
     url = "https://github.com/jonas-kr/PlotlyJS.jl/releases/download/plotly-artifacts/plotly-artifacts.tar.gz"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlotlyJS"
 uuid = "f0f68f2c-4968-5e81-91da-67840de0976a"
 authors = ["Spencer Lyon <spencerlyon2@gmail.com>"]
-version = "0.14.1"
+version = "0.15"
 
 [deps]
 Blink = "ad839575-38b3-5650-b840-f874b8c74a25"

--- a/README.md
+++ b/README.md
@@ -16,16 +16,7 @@ Check out the [docs](http://juliaplots.org/PlotlyJS.jl/stable)!
 
 ## Installation
 
-If you intend to use the [Electron display](http://juliaplots.github.io/PlotlyJS.jl/syncplots/#electronplot) or any of its features (recommended) you will need to enter the following at the Julia REPL:
-
-```julia
-using Blink
-Blink.AtomShell.install()
-```
-
-Note that this is a one time process.
-
-Also, if you have issues building this package because of installation of the MbedTLS  package please see [this issue](https://github.com/sglyon/PlotlyJS.jl/issues/83).
+If you have issues building this package because of installation of the MbedTLS  package please see [this issue](https://github.com/sglyon/PlotlyJS.jl/issues/83).
 
 ### Jupyterlab
 

--- a/deps/find_attr_groups.jl
+++ b/deps/find_attr_groups.jl
@@ -10,7 +10,7 @@ _symbol_dict(d::AbstractDict) =
 
 function main()
 
-    data = _symbol_dict(JSON.parsefile(joinpath(artifact"plotly-artifacts", "plot-schema.json")))
+    data = _symbol_dict(JSON.parsefile(joinpath(artifact"plotly-artifacts", "plot-schema.json")))[:schema]
 
     nms = Set{Symbol}()
     function add_to_names!(d::AbstractDict)

--- a/deps/generate_artifacts.jl
+++ b/deps/generate_artifacts.jl
@@ -2,7 +2,7 @@
 using Pkg.Artifacts
 using Downloads
 
-function generate_artifacts(ver="latest")
+function generate_artifacts(ver="latest",repo="https://github.com/JuliaPlots/PlotlyJS.jl")
     artifacts_toml = joinpath(dirname(@__DIR__), "Artifacts.toml")
 
     # if Artifacts.toml does not exist we also do not have to remove it
@@ -19,6 +19,6 @@ function generate_artifacts(ver="latest")
     tarball_hash = archive_artifact(plotlyartifacts_hash, "plotly-artifacts-$ver.tar.gz")
 
     bind_artifact!(artifacts_toml, "plotly-artifacts", plotlyartifacts_hash; download_info = [
-        ("https://github.com/JuliaPlots/PlotlyJS.jl/releases/download/plotly-artifacts-$ver/plotly-artifacts-$ver.tar.gz", tarball_hash)
+        ("$repo/releases/download/plotly-artifacts-$ver/plotly-artifacts-$ver.tar.gz", tarball_hash)
     ])
 end

--- a/deps/generate_artifacts.jl
+++ b/deps/generate_artifacts.jl
@@ -9,7 +9,7 @@ plotschema_url = "https://api.plot.ly/v2/plot-schema?sha1"
 plotly_url = "https://cdn.plot.ly/plotly-latest.min.js"
 
 plotlyartifacts_hash = create_artifact() do artifact_dir
-    download(plotschema_url, joinpath(artifact_dir, "plotschema.json"))
+    download(plotschema_url, joinpath(artifact_dir, "plot-schema.json"))
     download(plotly_url, joinpath(artifact_dir, "plotly-latest.min.js"))
 end
 

--- a/deps/generate_artifacts.jl
+++ b/deps/generate_artifacts.jl
@@ -1,20 +1,24 @@
 # This script gets run once, on a developer's machine, to generate artifacts
 using Pkg.Artifacts
+using Downloads
 
-artifacts_toml = joinpath(dirname(@__DIR__), "Artifacts.toml")
+function generate_artifacts(ver="latest")
+    artifacts_toml = joinpath(dirname(@__DIR__), "Artifacts.toml")
 
-rm(artifacts_toml)
+    # if Artifacts.toml does not exist we also do not have to remove it
+    isfile(artifacts_toml) && rm(artifacts_toml)
 
-plotschema_url = "https://api.plot.ly/v2/plot-schema?sha1"
-plotly_url = "https://cdn.plot.ly/plotly-latest.min.js"
+    plotschema_url = "https://api.plot.ly/v2/plot-schema?sha1"
+    plotly_url = "https://cdn.plot.ly/plotly-$ver.min.js"
 
-plotlyartifacts_hash = create_artifact() do artifact_dir
-    download(plotschema_url, joinpath(artifact_dir, "plot-schema.json"))
-    download(plotly_url, joinpath(artifact_dir, "plotly.min.js"))
+    plotlyartifacts_hash = create_artifact() do artifact_dir
+        Downloads.download(plotschema_url, joinpath(artifact_dir, "plot-schema.json"))
+        Downloads.download(plotly_url, joinpath(artifact_dir, "plotly.min.js"))
+    end
+
+    tarball_hash = archive_artifact(plotlyartifacts_hash, "plotly-artifacts-$ver.tar.gz")
+
+    bind_artifact!(artifacts_toml, "plotly-artifacts", plotlyartifacts_hash; download_info = [
+        ("https://github.com/JuliaPlots/PlotlyJS.jl/releases/download/plotly-artifacts-$ver/plotly-artifacts-$ver.tar.gz", tarball_hash)
+    ])
 end
-
-tarball_hash = archive_artifact(plotlyartifacts_hash, "plotly-artifacts.tar.gz")
-
-bind_artifact!(artifacts_toml, "plotly-artifacts", plotlyartifacts_hash; download_info = [
-    ("https://github.com/JuliaPlots/PlotlyJS.jl/releases/download/plotly-artifacts/plotly-artifacts.tar.gz", tarball_hash)
-])

--- a/deps/generate_artifacts.jl
+++ b/deps/generate_artifacts.jl
@@ -1,22 +1,23 @@
 # This script gets run once, on a developer's machine, to generate artifacts
 using Pkg.Artifacts
+using SHA
 
 artifacts_toml = joinpath(dirname(@__DIR__), "Artifacts.toml")
 
-rm(artifacts_toml)
+rm(artifacts_toml,force=true)
 
 plotschema_url = "https://api.plot.ly/v2/plot-schema?sha1"
-plotschema_hash = create_artifact() do artifact_dir
-    download(plotschema_url, joinpath(artifact_dir, "plotschema.json"))
-end
-bind_artifact!(artifacts_toml, "plotschema", plotschema_hash; download_info = [
-    (plotschema_url, plotschema_hash)
-])
-
 plotly_url = "https://cdn.plot.ly/plotly-latest.min.js"
-plotly_hash = create_artifact() do artifact_dir
+
+plotlyartifacts_hash = create_artifact() do artifact_dir
+    download(plotschema_url, joinpath(artifact_dir, "plotschema.json"))
     download(plotly_url, joinpath(artifact_dir, "plotly-latest.min.js"))
 end
-bind_artifact!(artifacts_toml, "plotly", plotly_hash; download_info = [
-    (plotly_url, plotly_hash)
+
+artifact_dir = artifact_path(plotlyartifacts_hash)
+bind_artifact!(artifacts_toml, "plotly-artifacts", plotlyartifacts_hash; download_info = [
+    (plotschema_url, bytes2hex(sha256(read(joinpath(artifact_dir, "plotschema.json"))))),
+    (plotly_url, bytes2hex(sha256(read(joinpath(artifact_dir, "plotly-latest.min.js"))))),
 ])
+
+archive_artifact(plotlyartifacts_hash, dirname(@__DIR__))

--- a/deps/generate_artifacts.jl
+++ b/deps/generate_artifacts.jl
@@ -1,10 +1,9 @@
 # This script gets run once, on a developer's machine, to generate artifacts
 using Pkg.Artifacts
-using SHA
 
 artifacts_toml = joinpath(dirname(@__DIR__), "Artifacts.toml")
 
-rm(artifacts_toml,force=true)
+rm(artifacts_toml)
 
 plotschema_url = "https://api.plot.ly/v2/plot-schema?sha1"
 plotly_url = "https://cdn.plot.ly/plotly-latest.min.js"
@@ -14,10 +13,8 @@ plotlyartifacts_hash = create_artifact() do artifact_dir
     download(plotly_url, joinpath(artifact_dir, "plotly-latest.min.js"))
 end
 
-artifact_dir = artifact_path(plotlyartifacts_hash)
-bind_artifact!(artifacts_toml, "plotly-artifacts", plotlyartifacts_hash; download_info = [
-    (plotschema_url, bytes2hex(sha256(read(joinpath(artifact_dir, "plotschema.json"))))),
-    (plotly_url, bytes2hex(sha256(read(joinpath(artifact_dir, "plotly-latest.min.js"))))),
-])
+tarball_hash = archive_artifact(plotlyartifacts_hash, "plotly-artifacts.tar.gz")
 
-archive_artifact(plotlyartifacts_hash, "plotly-artifacts.tar.gz")
+bind_artifact!(artifacts_toml, "plotly-artifacts", plotlyartifacts_hash; download_info = [
+    ("https://github.com/jonas-kr/PlotlyJS.jl/releases/download/plotly-artifacts/plotly-artifacts.tar.gz", tarball_hash)
+])

--- a/deps/generate_artifacts.jl
+++ b/deps/generate_artifacts.jl
@@ -16,5 +16,5 @@ end
 tarball_hash = archive_artifact(plotlyartifacts_hash, "plotly-artifacts.tar.gz")
 
 bind_artifact!(artifacts_toml, "plotly-artifacts", plotlyartifacts_hash; download_info = [
-    ("https://github.com/jonas-kr/PlotlyJS.jl/releases/download/plotly-artifacts/plotly-artifacts.tar.gz", tarball_hash)
+    ("https://github.com/JuliaPlots/PlotlyJS.jl/releases/download/plotly-artifacts/plotly-artifacts.tar.gz", tarball_hash)
 ])

--- a/deps/generate_artifacts.jl
+++ b/deps/generate_artifacts.jl
@@ -20,4 +20,4 @@ bind_artifact!(artifacts_toml, "plotly-artifacts", plotlyartifacts_hash; downloa
     (plotly_url, bytes2hex(sha256(read(joinpath(artifact_dir, "plotly-latest.min.js"))))),
 ])
 
-archive_artifact(plotlyartifacts_hash, dirname(@__DIR__))
+archive_artifact(plotlyartifacts_hash, "plotly-artifacts.tar.gz")

--- a/deps/generate_artifacts.jl
+++ b/deps/generate_artifacts.jl
@@ -10,7 +10,7 @@ plotly_url = "https://cdn.plot.ly/plotly-latest.min.js"
 
 plotlyartifacts_hash = create_artifact() do artifact_dir
     download(plotschema_url, joinpath(artifact_dir, "plot-schema.json"))
-    download(plotly_url, joinpath(artifact_dir, "plotly-latest.min.js"))
+    download(plotly_url, joinpath(artifact_dir, "plotly.min.js"))
 end
 
 tarball_hash = archive_artifact(plotlyartifacts_hash, "plotly-artifacts.tar.gz")

--- a/deps/make_schema_docs.jl
+++ b/deps/make_schema_docs.jl
@@ -73,7 +73,7 @@ struct Schema
 
     function Schema()
         _path = joinpath(artifact"plotly-artifacts", "plot-schema.json")
-        schema = _symbol_dict(JSON.parse(read(_path, String)))
+        schema = _symbol_dict(JSON.parse(read(_path, String)))[:schema]
 
         traces = Dict{Symbol,TraceSchema}()
         for (k, v) in schema[:traces]


### PR DESCRIPTION
This pull request comprises the generation of the plotly-artifacts using GitHub Actions. We can (for now) manually run the action "artifacts" to update (or generate) the tarball "plotly-artifacts.tar.gz" which is available as a release. The Artifacts.toml file is then updated automatically.

As a side effect, this pull request resolves #369 and #370 .

Please feel free to propose further changes!  👍 

EDIT: Unfortunately, the Documenter workflow is currently broken since the update of the hash in the file Artifact.toml happens in a separate commit.