### PR TITLE
Savefig has been removed from PlotlyBase

### DIFF
--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -11,7 +11,7 @@ import PlotlyBase:
     restyle!, relayout!, update!, addtraces!, deletetraces!, movetraces!,
     redraw!, extendtraces!, prependtraces!, purge!, to_image, download_image,
     restyle, relayout, update, addtraces, deletetraces, movetraces, redraw,
-    extendtraces, prependtraces, prep_kwargs, sizes, savefig, _tovec,
+    extendtraces, prependtraces, prep_kwargs, sizes, _tovec,
     react, react!, add_trace!
 
 using WebIO


### PR DESCRIPTION
Reference: https://github.com/sglyon/PlotlyBase.jl/pull/58

https://github.com/JuliaPlots/Plots.jl/issues/3703