### PR TITLE
add upper bound for WebIO compat entry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ JSON = "0.20, 0.21"
 PlotlyBase = "0.8.15"
 Reexport = "0.2, 1"
 Requires = "1.0"
-WebIO = "0.8"
+WebIO = "0.8.0 - 0.8.17"
 julia = "1.3, 1.4, 1.5, 1.6"
 
 [extras]


### PR DESCRIPTION
This is a short term remedy for #440, once WebIO fixes this one way or another this should be revisited.

Fix #440 