### PR TITLE
Remove WebIO upper bound (no longer needed)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ JSON = "0.20, 0.21"
 PlotlyBase = "0.8.15"
 Reexport = "0.2, 1"
 Requires = "1.0"
-WebIO = "0.8.0 - 0.8.17"
+WebIO = "0.8"
 julia = "1.3, 1.4, 1.5, 1.6"
 
 [extras]


### PR DESCRIPTION
With the fix in https://github.com/JuliaGizmos/Observables.jl/pull/97 reintroducing `setexcludinghandlers!`, the upper bound on WebIO is no longer need.