### PR TITLE
Remove Blink dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.18.10"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-Blink = "ad839575-38b3-5650-b840-f874b8c74a25"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 JSExpr = "97c1335a-c9c5-57fe-bc5d-ec35cebe8660"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -19,13 +18,11 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
 
 [compat]
-Blink = "0.12"
 JSExpr = "0.5, 1"
 JSON = "0.20, 0.21"
 PlotlyBase = "0.8.15"
 Reexport = "0.2, 1"
 Requires = "1.0"
-WebIO = "0.8"
 julia = "1.3, 1.4, 1.5, 1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -23,6 +23,7 @@ JSON = "0.20, 0.21"
 PlotlyBase = "0.8.15"
 Reexport = "0.2, 1"
 Requires = "1.0"
+WebIO = "0.8"
 julia = "1.3, 1.4, 1.5, 1.6"
 
 [extras]

--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -4,6 +4,7 @@ using Base64
 using Reexport
 @reexport using PlotlyBase
 using JSON
+using WebIO
 using REPL, Pkg, Pkg.Artifacts, DelimitedFiles  # stdlib
 
 # need to import some functions because methods are meta-generated
@@ -14,10 +15,8 @@ import PlotlyBase:
     extendtraces, prependtraces, prep_kwargs, sizes, _tovec,
     react, react!, add_trace!
 
-using WebIO
 using JSExpr
 using JSExpr: @var, @new
-using Blink
 using Pkg.Artifacts
 using Requires
 
@@ -41,21 +40,9 @@ make_subplots(;kwargs...) = plot(Layout(Subplots(;kwargs...)))
 
 @doc (@doc Subplots) make_subplots
 
-function docs()
-    schema_path = joinpath(dirname(dirname(@__FILE__)), "deps", "schema.html")
-    if !isfile(schema_path)
-        msg = "schema docs not built. Run `Pkg.build(\"PlotlyJS\")` to generate"
-        error(msg)
-    end
-    w = Blink.Window()
-    wait(w.content)
-    Blink.content!(w, "html", open(f -> read(f, String), schema_path), fade=false, async=false)
-end
+@enum RENDERERS IJULIA BROWSER
 
-
-@enum RENDERERS BLINK IJULIA BROWSER DOCS
-
-const DEFAULT_RENDERER = Ref(BLINK)
+const DEFAULT_RENDERER = Ref(BROWSER)
 
 function set_default_renderer(s::RENDERERS)
     global DEFAULT_RENDERER
@@ -142,11 +129,11 @@ function __init__()
             Dict(
                 "application/vnd.plotly.v1+json" => JSON.lower(p),
                 "text/plain" => sprint(show, "text/plain", p),
-                "text/html" => let
-                    buf = IOBuffer()
-                    show(buf, MIME("text/html"), p)
-                    String(resize!(buf.data, buf.size))
-                end
+                # "text/html" => let
+                #     buf = IOBuffer()
+                #     show(buf, MIME("text/html"), p)
+                #     String(resize!(buf.data, buf.size))
+                # end
             )
         end
     end

--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -38,17 +38,6 @@ make_subplots(;kwargs...) = plot(Layout(Subplots(;kwargs...)))
 
 @doc (@doc Subplots) make_subplots
 
-@enum RENDERERS IJULIA BROWSER
-
-const DEFAULT_RENDERER = Ref(BROWSER)
-
-function set_default_renderer(s::RENDERERS)
-    global DEFAULT_RENDERER
-    DEFAULT_RENDERER[] = s
-end
-
-@inline get_renderer() = DEFAULT_RENDERER[]
-
 list_datasets() = readdir(joinpath(artifact"plotly-artifacts", "datasets"))
 function check_dataset_exists(name::String)
     ds = list_datasets()
@@ -85,24 +74,6 @@ function __init__()
     if !isfile(_js_path)
         @info("plotly.js javascript libary not found -- downloading now")
         include(joinpath(_pkg_root, "deps", "build.jl"))
-    end
-
-    # set default renderer
-    # First check env var
-    env_val = get(ENV, "PLOTLY_RENDERER_JULIA", missing)
-    if !ismissing(env_val)
-        env_symbol = Symbol(uppercase(env_val))
-        options = Dict(v => k for (k, v) in collect(Base.Enums.namemap(PlotlyJS.RENDERERS)))
-        renderer_int = get(options, env_symbol, missing)
-        if ismissing(renderer_int)
-            @warn "Unknown value for env var `PLOTLY_RENDERER_JULIA` \"$(env_val)\", known options are $(string.(keys(options)))"
-        else
-            set_default_renderer(RENDERERS(renderer_int))
-        end
-    else
-        # we have no env-var
-        # check IJULIA
-        isdefined(Main, :IJulia) && Main.IJulia.inited && set_default_renderer(IJULIA)
     end
 
     @require JSON2 = "2535ab7d-5cd8-5a07-80ac-9b1792aadce3" JSON2.write(io::IO, p::SyncPlot) = JSON2.write(io, p.plot)

--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -4,7 +4,6 @@ using Base64
 using Reexport
 @reexport using PlotlyBase
 using JSON
-using WebIO
 using REPL, Pkg, Pkg.Artifacts, DelimitedFiles  # stdlib
 
 # need to import some functions because methods are meta-generated
@@ -15,6 +14,7 @@ import PlotlyBase:
     extendtraces, prependtraces, prep_kwargs, sizes, _tovec,
     react, react!, add_trace!
 
+using WebIO
 using JSExpr
 using JSExpr: @var, @new
 using Pkg.Artifacts
@@ -117,11 +117,11 @@ function __init__()
             Dict(
                 "application/vnd.plotly.v1+json" => JSON.lower(p),
                 "text/plain" => sprint(show, "text/plain", p),
-                # "text/html" => let
-                #     buf = IOBuffer()
-                #     show(buf, MIME("text/html"), p)
-                #     String(resize!(buf.data, buf.size))
-                # end
+                "text/html" => let
+                    buf = IOBuffer()
+                    show(buf, MIME("text/html"), p)
+                    String(resize!(buf.data, buf.size))
+                end
             )
         end
     end

--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -29,8 +29,6 @@ const _js_cdn_path = "https://cdn.plot.ly/plotly-latest.min.js"
 const _mathjax_cdn_path =
     "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_SVG"
 
-struct PlotlyJSDisplay <: AbstractDisplay end
-
 # include the rest of the core parts of the package
 include("display.jl")
 include("util.jl")
@@ -106,16 +104,6 @@ function __init__()
         # check IJULIA
         isdefined(Main, :IJulia) && Main.IJulia.inited && set_default_renderer(IJULIA)
     end
-
-    # set up display
-    insert!(Base.Multimedia.displays, findlast(x -> x isa Base.TextDisplay || x isa REPL.REPLDisplay, Base.Multimedia.displays) + 1, PlotlyJSDisplay())
-
-    atreplinit(i -> begin
-        while PlotlyJSDisplay() in Base.Multimedia.displays
-            popdisplay(PlotlyJSDisplay())
-        end
-        insert!(Base.Multimedia.displays, findlast(x -> x isa REPL.REPLDisplay, Base.Multimedia.displays) + 1, PlotlyJSDisplay())
-    end)
 
     @require JSON2 = "2535ab7d-5cd8-5a07-80ac-9b1792aadce3" JSON2.write(io::IO, p::SyncPlot) = JSON2.write(io, p.plot)
     @require JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1" begin

--- a/src/display.jl
+++ b/src/display.jl
@@ -142,7 +142,7 @@ function SyncPlot(
     # to us
     on(scope["image"]) do x end
 
-    SyncPlot(p, scope, nothing)
+    SyncPlot(p, scope)
 end
 
 function plot(args...; kwargs...)


### PR DESCRIPTION
Disclaimer: This PR is not-entirely-serious, and is mostly intended to start a discussion.

Blink is a large dependency with a correspondingly large load time (`@time using Blink # 2.42 seconds on my PC`).

There are two major benefits from removing Blink as a dependency:

- Faster load times.
  - `@time using PlotlyJS` drops from 3.12 to 1.02 seconds, with matching decreases in number of allocations and total allocated memory.
- Reduced direct and transitive dependencies.
  - In particular, without Blink, there is no transitive dependency on WebSockets, which is incompatible with new(er) versions of HTTP > v1. The presence of WebSockets in the environment downgrades HTTP and any packages/versions depending on recent versions of HTTP, which is particularly inconvenient in large environments (which despite recommendations to the contrary, are the norm from what I can tell).

Some relevant questions:

- How many users depend on the Blink functionality vs using Jupyter?
- Do the number of Blink users justify a 3x loading time?
- Could we split this out into a separate package?
