### PR TITLE
Fix precompilation of packages depending on PlotlyJS

### DIFF
--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -169,10 +169,7 @@ function __init__()
     if ccall(:jl_generating_output, Cint, ()) == 1
         # ensure precompilation of packages depending on PlotlyJS finishes
         if isdefined(P, :proc)
-            close(P.proc)
             close(P.stdin)
-            close(P.stdout)
-            close(P.stderr)
             wait(P.proc)
         end
     end

--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -95,7 +95,7 @@ function __init__()
         @warn("Warnings were generated during the last build of PlotlyJS:  please check the build log at $_build_log")
     end
 
-    @async _start_kaleido_process()
+    kaleido_task = Base.Threads.@spawn _start_kaleido_process()
 
     if !isfile(_js_path)
         @info("plotly.js javascript libary not found -- downloading now")
@@ -161,6 +161,19 @@ function __init__()
         end
         @require DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0" begin
             dataset(::Type{DataFrames.DataFrame}, name::String) = DataFrames.DataFrame(dataset(CSV.File, name))
+        end
+    end
+
+    wait(kaleido_task)
+
+    if ccall(:jl_generating_output, Cint, ()) == 1
+        # ensure precompilation of packages depending on PlotlyJS finishes
+        if isdefined(P, :proc)
+            close(P.proc)
+            close(P.stdin)
+            close(P.stdout)
+            close(P.stderr)
+            sleep(0.1) # avoid a "waiting for IO to finish" warning
         end
     end
 end

--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -173,7 +173,7 @@ function __init__()
             close(P.stdin)
             close(P.stdout)
             close(P.stderr)
-            sleep(0.1) # avoid a "waiting for IO to finish" warning
+            wait(P.proc)
         end
     end
 end


### PR DESCRIPTION
Starting from Julia v1.10, using PlotlyJS.jl as a dependency of any other package causes the precompilation of this other package to be stuck, as explained in https://github.com/JuliaLang/julia/issues/50505. This PR fixes that.

The root cause of the issue was https://github.com/JuliaLang/julia/issues/48506. To be honest, I'm not sure I understand why the behavior of the `__init__` function of PlotlyJS should livelock the precompilation of *other* packages... but I was inspired by https://github.com/JuliaDebug/Cthulhu.jl/pull/343/files and https://github.com/JuliaImages/ImageView.jl/pull/279/files, which targeted similar issues, for this PR.