### PR TITLE
Use the same plotlyjs version number for all imports

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -13,9 +13,6 @@ jobs:
   gen-artifacts:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    # The plotly version. Bumping this environment variable should do the trick
-    env:
-      PLOTLY_VER: 2.3.0
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -33,7 +30,7 @@ jobs:
       - name: "Get artifact"
         run: |
           cd $GITHUB_WORKSPACE
-          julia -e 'include(joinpath(pwd(),"deps","generate_artifacts.jl")); generate_artifacts("'"$PLOTLY_VER"'","'"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"'")'
+          julia -e 'include(joinpath(pwd(),"deps","generate_artifacts.jl")); generate_artifacts("'"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"'")'
 
       - name: "Commit updated Artifacts.toml"
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@ tags/
 tags
 site/
 .ipynb_checkpoints/
-assets/plotly-latest.min.js
-deps/plotly-latest.min.js
+assets/plotly-*.min.js
+deps/plotly-*.min.js
 deps/plotschema.json
 deps/schema.html
 deps/*.csv

--- a/deps/generate_artifacts.jl
+++ b/deps/generate_artifacts.jl
@@ -2,7 +2,9 @@
 using Pkg.Artifacts
 using Downloads
 
-function generate_artifacts(ver="latest", repo="https://github.com/JuliaPlots/PlotlyJS.jl")
+ver = include("./plotly_cdn_version.jl")
+
+function generate_artifacts(repo="https://github.com/JuliaPlots/PlotlyJS.jl")
     artifacts_toml = joinpath(dirname(@__DIR__), "Artifacts.toml")
 
     # if Artifacts.toml does not exist we also do not have to remove it

--- a/deps/plotly_cdn_version.jl
+++ b/deps/plotly_cdn_version.jl
@@ -1,0 +1,2 @@
+# run the artifacts.yml Github Action after changing this file
+"2.3.0"

--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -26,7 +26,8 @@ export plot, dataset, list_datasets, make_subplots, savefig, mgrid
 # globals for this package
 const _pkg_root = dirname(dirname(@__FILE__))
 const _js_path = joinpath(artifact"plotly-artifacts", "plotly.min.js")
-const _js_cdn_path = "https://cdn.plot.ly/plotly-latest.min.js"
+const _js_version = include(joinpath(_pkg_root, "deps", "plotly_cdn_version.jl"))
+const _js_cdn_path = "https://cdn.plot.ly/plotly-$(_js_version).min.js"
 const _mathjax_cdn_path =
     "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_SVG"
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -31,7 +31,7 @@ function SyncPlot(
 
     # setup scope
     deps = [
-        "Plotly" => joinpath(artifact"plotly-artifacts", "plotly.min.js"),
+        "Plotly" => _js_path,
         joinpath(@__DIR__, "..", "assets", "plotly_webio.bundle.js")
     ]
     scope = Scope(imports=deps)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,4 +10,9 @@ const M = PlotlyJS
 # include("blink.jl")
 include("kaleido.jl")
 
+# these are public API
+@test isfile(PlotlyJS._js_path)
+@test !isempty(PlotlyJS._js_version)
+@test !startswith(PlotlyJS._js_version, "v")
+
 end


### PR DESCRIPTION
This PR makes sure that the same version of the plotlyjs web asset is used for all imports: through artifact or through CDN.

This also adds `_js_version` and `_js_path` as public API: this means other packages can depend on PlotlyJS.jl to get the plotly.min.js asset. Used in https://github.com/JuliaPlots/Plots.jl/pull/4862