### PR TITLE
Enhance savefig()

### DIFF
--- a/docs/src/manipulating_plots.md
+++ b/docs/src/manipulating_plots.md
@@ -138,70 +138,56 @@ More examples are being worked on at this time (2021-07-14), but for now you can
 
 ## Saving figures
 
-
-Figures can be saved in a variety of formats using the `savefig` function.
+Figures can be saved in a variety of formats using the [`savefig`](@ref) function.
 
 !!! note
-   Note that the docs below are shown for the `PlotlyBase.Plot` type, but are also defined for `PlotlyJS.SyncPlot`. Thus, you can use these methods after calling either `plot` or `Plot`.
+   Note that the docs below are shown for the `PlotlyBase.Plot` type, but are also defined for `PlotlyJS.SyncPlot`.
+   Thus, you can use these methods after calling either `plot` or `Plot`.
 
-This function has a few methods:
+The `savefig` function can be called in a few ways:
 
-**1**
+**Save into a file**
+
+`savefig(p, filename)` saves the plot `p` into `filename`.
+Unless explicitly specified, the format of the file is inferred from the `filename` extension.
+The examples demonstrate the supported formats:
+
+```julia
+savefig(p, "output_filename.pdf")
+savefig(p, "output_filename.html")
+savefig(p, "output_filename.json")
+savefig(p, "output_filename.png")
+savefig(p, "output_filename.svg")
+savefig(p, "output_filename.jpeg")
+savefig(p, "output_filename.webp")
+```
+
+**Save into a stream**
+
+`savefig(io, p)` saves the plot `p` into the open `io` stream.
+The figure format could be specified with the `format` keyword, the default format is *PNG*.
+
+**Display on the screen**
+
+*PlotlyJS.jl* overloads the `Base.show` method to hook into Julia's rich display system:
+```julia
+Base.show(io::IO, ::MIME, p::Union{PlotlyBase.Plot})
+```
+Internally, this `Base.show` implementation calls `savefig(io, p)`,
+and the `MIME` argument allows to specify the output format.
+
+The following MIME formats are supported:
+    * `::MIME"application/pdf`
+    * `::MIME"image/png`
+    * `::MIME"image/svg+xml`
+    * `::MIME"image/eps`
+    * `::MIME"image/jpeg`
+    * `::MIME"application/json"`
+    * `::MIME"application/json; charset=UTF-8"`
 
 ```@docs
-savefig(::Union{PlotlyBase.Plot}, ::String)
+savefig
 ```
-
-When using this method the format of the file is inferred based on the extension
-of the second argument. The examples below show the possible export formats:
-
-```julia
-savefig(p::Union{Plot,SyncPlot}, "output_filename.pdf")
-savefig(p::Union{Plot,SyncPlot}, "output_filename.html")
-savefig(p::Union{Plot,SyncPlot}, "output_filename.json")
-savefig(p::Union{Plot,SyncPlot}, "output_filename.png")
-savefig(p::Union{Plot,SyncPlot}, "output_filename.svg")
-savefig(p::Union{Plot,SyncPlot}, "output_filename.jpeg")
-savefig(p::Union{Plot,SyncPlot}, "output_filename.webp")
-```
-
-**2**
-
-```julia
-savefig(
-    io::IO,
-    p::Plot;
-    width::Union{Nothing,Int}=nothing,
-    height::Union{Nothing,Int}=nothing,
-    scale::Union{Nothing,Real}=nothing,
-    format::String="png"
-)
-```
-
-This method allows you to save a plot directly to an open IO stream.
-
-See the [`savefig(::IO, ::PlotlyBase.Plot)`](@ref) API docs for more information.
-
-**3**
-
-```julia
-Base.show(::IO, ::MIME, ::Union{PlotlyBase.Plot})
-```
-
-This method hooks into Julia's rich display system.
-
-Possible arguments for the second argument are shown in the examples below:
-
-```julia
-savefig(io::IO, ::MIME"application/pdf", p::Union{Plot,SyncPlot})
-savefig(io::IO, ::MIME"image/png", p::Union{Plot,SyncPlot})
-savefig(io::IO, ::MIME"image/svg+xml", p::Union{Plot,SyncPlot})
-savefig(io::IO, ::MIME"image/eps", p::Union{Plot,SyncPlot})
-savefig(io::IO, ::MIME"image/jpeg", p::Union{Plot,SyncPlot})
-savefig(io::IO, ::MIME"application/json", p::Union{Plot,SyncPlot})
-savefig(io::IO, ::MIME"application/json; charset=UTF-8", p::Union{Plot,SyncPlot})
-```
-
 !!! note
     You can also save the json for a figure by calling
     `savejson(p::Union{Plot,SyncPlot}, filename::String)`.

--- a/docs/src/manipulating_plots.md
+++ b/docs/src/manipulating_plots.md
@@ -141,8 +141,8 @@ More examples are being worked on at this time (2021-07-14), but for now you can
 Figures can be saved in a variety of formats using the [`savefig`](@ref) function.
 
 !!! note
-   Note that the docs below are shown for the `PlotlyBase.Plot` type, but are also defined for `PlotlyJS.SyncPlot`.
-   Thus, you can use these methods after calling either `plot` or `Plot`.
+    Note that the docs below are shown for the `PlotlyBase.Plot` type, but are also defined for `PlotlyJS.SyncPlot`.
+    Thus, you can use these methods after calling either `plot` or `Plot`.
 
 The `savefig` function can be called in a few ways:
 
@@ -177,13 +177,13 @@ Internally, this `Base.show` implementation calls `savefig(io, p)`,
 and the `MIME` argument allows to specify the output format.
 
 The following MIME formats are supported:
-    * `::MIME"application/pdf`
-    * `::MIME"image/png`
-    * `::MIME"image/svg+xml`
-    * `::MIME"image/eps`
-    * `::MIME"image/jpeg`
-    * `::MIME"application/json"`
-    * `::MIME"application/json; charset=UTF-8"`
+ * `::MIME"application/pdf`
+* `::MIME"image/png`
+* `::MIME"image/svg+xml`
+* `::MIME"image/eps`
+* `::MIME"image/jpeg`
+* `::MIME"application/json"`
+* `::MIME"application/json; charset=UTF-8"`
 
 ```@docs
 savefig

--- a/docs/src/manipulating_plots.md
+++ b/docs/src/manipulating_plots.md
@@ -177,7 +177,7 @@ Internally, this `Base.show` implementation calls `savefig(io, p)`,
 and the `MIME` argument allows to specify the output format.
 
 The following MIME formats are supported:
- * `::MIME"application/pdf`
+* `::MIME"application/pdf`
 * `::MIME"image/png`
 * `::MIME"image/svg+xml`
 * `::MIME"image/eps`

--- a/src/display.jl
+++ b/src/display.jl
@@ -23,7 +23,7 @@ end
 Base.show(io::IO, mm::MIME"application/prs.juno.plotpane+html", p::SyncPlot) = show(io, mm, p.scope)
 
 # using @eval instead of Union{} to avoid ambiguity with other methods
-for mime in [MIME"text/plain", MIME"application/vnd.plotly.v1+json", MIME"application/prs.juno.plotpane+html"]
+for mime in [MIME"text/plain", MIME"application/vnd.plotly.v1+json", MIME"juliavscode/html"]
     @eval Base.show(io::IO, mm::$mime, p::SyncPlot, args...; kwargs...) = show(io, mm, p.plot, args...; kwargs...)
 end
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -22,6 +22,11 @@ function Base.show(io::IO, mm::MIME"text/html", p::SyncPlot)
 end
 Base.show(io::IO, mm::MIME"application/prs.juno.plotpane+html", p::SyncPlot) = show(io, mm, p.scope)
 
+# using @eval instead of Union{} to avoid ambiguity with other methods
+for mime in [MIME"text/plain", MIME"application/vnd.plotly.v1+json", MIME"application/prs.juno.plotpane+html"]
+    @eval Base.show(io::IO, mm::$mime, p::SyncPlot, args...; kwargs...) = show(io, mm, p.plot, args...; kwargs...)
+end
+
 function SyncPlot(
         p::Plot;
         kwargs...
@@ -340,13 +345,6 @@ for f in (:extendtraces!, :prependtraces!)
                       maxpoints=-1)
             ($f)(p, update, [ind], maxpoints)
         end
-    end
-end
-
-
-for mime in ["text/plain", "application/vnd.plotly.v1+json", "application/prs.juno.plotpane+html"]
-    function Base.show(io::IO, m::MIME{Symbol(mime)}, p::SyncPlot, args...)
-        show(io, m, p.plot, args...)
     end
 end
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -20,7 +20,7 @@ function Base.show(io::IO, mm::MIME"text/html", p::SyncPlot)
     end
     show(io, mm, p.scope)
 end
-Base.show(io::IO, mm::MIME"application/prs.juno.plotpane+html", p::SyncPlot) = show(io, mm, p.scope)
+Base.show(io::IO, mm::MIME"juliavscode/html", p::SyncPlot) = show(io, mm, p.scope)
 
 # using @eval instead of Union{} to avoid ambiguity with other methods
 for mime in [MIME"text/plain", MIME"application/vnd.plotly.v1+json", MIME"juliavscode/html"]

--- a/src/kaleido.jl
+++ b/src/kaleido.jl
@@ -121,7 +121,7 @@ function _ensure_kaleido_running(;
         if !isnothing(plotly_version)
             restart(; plotly_version, kwargs...)
         else
-            resstart(; plotlyjs=something(plotlyjs, _js_path), kwargs...)
+            restart(; plotlyjs=something(plotlyjs, _js_path), kwargs...)
         end
     end
 end

--- a/src/kaleido.jl
+++ b/src/kaleido.jl
@@ -1,7 +1,5 @@
 using PlotlyKaleido: kill, is_running, start, restart, ALL_FORMATS, TEXT_FORMATS
 
-savefig(p::SyncPlot; kwargs...) = savefig(p.plot; kwargs...)
-
 """
     savefig(
         [io::IO], p::Plot, [fn:AbstractString];
@@ -77,6 +75,7 @@ function savefig(
     end
 end
 
+savefig(p::SyncPlot; kwargs...) = savefig(p.plot; kwargs...)
 
 @inline _get_Plot(p::Plot) = p
 @inline _get_Plot(p::SyncPlot) = p.plot
@@ -138,17 +137,13 @@ const _KALEIDO_MIMES = Dict(
 )
 
 for (mime, fmt) in _KALEIDO_MIMES
-    @eval function Base.show(
+    @eval Base.show(
         io::IO, ::MIME{Symbol($mime)}, plt::Plot;
         kwargs...
-    )
-        savefig(io, plt; format=$fmt, kwargs...)
-    end
+    ) = savefig(io, plt; format=$fmt, kwargs...)
 
-    @eval function Base.show(
+    @eval Base.show(
         io::IO, ::MIME{Symbol($mime)}, plt::SyncPlot;
         kwargs...
-    )
-        savefig(io, plt.plot; format=$fmt, kwargs...)
-    end
+    ) = savefig(io, plt.plot; format=$fmt, kwargs...)
 end


### PR DESCRIPTION
This PR does 2 things:
  * cleanup `savefig()`: combine docstring from all 3 versions, streamline keyword argument passing using `kwargs...`
  * add `plotlyjs` and `plotly_version` keyword arguments to `savefig()` to control which *plotly.js* Kaleido would be using to generate the figures.
    This is to allow using more recent versions of *plotly.js* than the one provided by the *PlotlyJS.jl* (the current one, 2.3.0, is more than a year old).

I have also regenerated the *plotly.js* artifact using version *2.35.2*.
I can provide the file, or the maintainers can run `generate_artifacts.jl` themselves.

See also [comment for PlotlyBase.jl#106](https://github.com/sglyon/PlotlyBase.jl/pull/106#issuecomment-2534636986)